### PR TITLE
Added 'image' effect.

### DIFF
--- a/project.json
+++ b/project.json
@@ -81,6 +81,13 @@
                 "type": "slider",
                 "value": 3
             },
+			"custom_color_image" : 
+			{
+				"condition" : "custom_color_mode.value == 4",
+				"order" : 104,
+				"text" : "ui_custom_color_image",
+				"type" : "file"
+			},
             "custom_color_mode": {
                 "options": [
                     {
@@ -94,6 +101,10 @@
                     {
                         "label": "ui_custom_color_mode_rainbow",
                         "value": 3
+                    },
+					{
+                        "label": "ui_custom_color_mode_image",
+                        "value": 4
                     }
                 ],
                 "order": 103,
@@ -261,10 +272,12 @@
                 "ui_custom_color_fixed": "Hexagon color<br/>",
                 "ui_custom_color_rainbow_scale" : "Rainbow scale",
                 "ui_custom_color_rainbow_offset_speed" : "Rainbow movement speed",
+                "ui_custom_color_image" : "Hexagon color image",
                 "ui_custom_color_mode": "Color mode",
                 "ui_custom_color_mode_circulating": "Circulating",
                 "ui_custom_color_mode_fixed": "Fixed",
                 "ui_custom_color_mode_rainbow" : "Rainbow",
+                "ui_custom_color_mode_image" : "Image",
                 "ui_custom_decay_factor": "Light decay speed %<br/><small>Higher decay speed means lights travel shorter distances.</small>",
                 "ui_custom_displacement_x": "Displacement X %",
                 "ui_custom_displacement_y": "Displacement Y %",


### PR DESCRIPTION
A new line effect has been added which bases the color of each line at a given point off of an image uploaded by the user. This is done by converting the RGB value at the scaled location of the line to HSL (via a new RGBtoHSL function derived from an original implemented for converting the fixed color input). The effect has been tested with various images. This allows the user to define their own patterns for the hexagon colors to follow. Patterns that include black portions are interesting as they appear to occlude the line against the black background in some areas.

Some patterns that have been tested:
- Black and white stripes and checker pattern
- Color spectrum
- Pastel color spectrum
- Red and green stripes
- Red and orange "noisy" stripes (the lines between colors were not exact)
- Flag of the USA
- Various "color palette" images (images with 5 or 6 colors in parallel)